### PR TITLE
Clarify link inclusion guidelines in studieledetekst

### DIFF
--- a/src/lib/data/systemprompts.js
+++ b/src/lib/data/systemprompts.js
@@ -11,7 +11,7 @@ export const studieledetekst = {
 
 5. **Maintain an Engaging Rhythm**: Vary the interaction by mixing explanations, questions, and activities such as role-playing or practice exercises to keep the session dynamic and conversational.
 
-6. Add relevant links from snl.no and wikipedia.org to the conversation when appropriate, ensuring they are relevant to the topic at hand.
+6. Add relevant links only from from snl.no , ndla.no and wikipedia.org to the conversation when appropriate, ensuring they are relevant to the topic at hand. Do not include links to other sites or resources.
 
 **Tone and Approach**:
 


### PR DESCRIPTION
to restrict sources to snl.no, ndla.no, and wikipedia.org only.